### PR TITLE
feat: allow to provide processorOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12731,6 +12731,15 @@
         }
       }
     },
+    "postcss-safe-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+      "integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.26"
+      }
+    },
     "postcss-selector-parser": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "node-sass": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.32",
+    "postcss-safe-parser": "^4.0.2",
     "prettier": "^2.1.2",
     "sass-loader": "^10.0.2",
     "standard-version": "^9.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ class CssMinimizerPlugin {
 
     const {
       minify,
+      processorOptions = {},
       minimizerOptions = {
         preset: 'default',
       },
@@ -57,6 +58,7 @@ class CssMinimizerPlugin {
       include,
       exclude,
       minify,
+      processorOptions,
       minimizerOptions,
     };
   }
@@ -331,6 +333,7 @@ class CssMinimizerPlugin {
                 input,
                 inputSourceMap,
                 map: this.options.sourceMap,
+                processorOptions: this.options.processorOptions,
                 minimizerOptions: this.options.minimizerOptions,
                 minify: this.options.minify,
               };

--- a/src/minify.js
+++ b/src/minify.js
@@ -12,19 +12,21 @@ const minify = async (options) => {
   const {
     name,
     input,
+    processorOptions,
     minimizerOptions,
     map,
     inputSourceMap,
     minify: minifyFn,
   } = options;
 
-  const postcssOptions = { to: name, from: name };
+  const postcssOptions = { to: name, from: name, ...processorOptions };
 
   if (minifyFn) {
     const result = await minifyFn(
       { [name]: input },
       inputSourceMap,
-      minimizerOptions
+      minimizerOptions,
+      processorOptions
     );
 
     return {

--- a/src/options.json
+++ b/src/options.json
@@ -73,6 +73,11 @@
         }
       ]
     },
+    "processorOptions": {
+      "description": "Options for the CSS processor.",
+      "additionalProperties": true,
+      "type": "object"
+    },
     "minimizerOptions": {
       "description": "Options for `cssMinimizerOptions`.",
       "additionalProperties": true,

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -154,5 +154,5 @@ exports[`validation 13`] = `
 exports[`validation 14`] = `
 "Invalid options object. Css Minimizer Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { test?, include?, exclude?, sourceMap?, minimizerOptions?, cache?, cacheKeys?, parallel?, warningsFilter?, minify? }"
+   object { test?, include?, exclude?, sourceMap?, processorOptions?, minimizerOptions?, cache?, cacheKeys?, parallel?, warningsFilter?, minify? }"
 `;

--- a/test/cssProcessorOptions-option.test.js
+++ b/test/cssProcessorOptions-option.test.js
@@ -1,0 +1,36 @@
+import safeParser from 'postcss-safe-parser';
+
+import CssMinimizerPlugin from '../src/index';
+
+import { getCompiler, compile, readAsset, removeCache } from './helpers';
+
+describe('when applied with "processorOptions" option', () => {
+  beforeEach(() => Promise.all([removeCache()]));
+
+  afterEach(() => Promise.all([removeCache()]));
+
+  it('matches snapshot for "parser" option (with safe parser)', () => {
+    const compiler = getCompiler({
+      entry: {
+        entry: `${__dirname}/fixtures/processorOptions/parser.css`,
+      },
+    });
+    new CssMinimizerPlugin({
+      parallel: false,
+      processorOptions: {
+        parser: safeParser,
+      },
+    }).apply(compiler);
+
+    return compile(compiler).then((stats) => {
+      expect(stats.compilation.errors).toEqual([]);
+      expect(stats.compilation.warnings).toEqual([]);
+
+      for (const file in stats.compilation.assets) {
+        // eslint-disable-next-line no-continue
+        if (/\.js$/.test(file)) continue;
+        expect(readAsset(file, compiler, stats)).toMatchSnapshot(file);
+      }
+    });
+  });
+});

--- a/test/fixtures/processorOptions/parser.css
+++ b/test/fixtures/processorOptions/parser.css
@@ -1,0 +1,1 @@
+a { color: red;


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Solves https://github.com/webpack-contrib/css-minimizer-webpack-plugin/issues/54

### Breaking Changes

None

### Additional Info

@alexander-akait 
I'm hitting some problems when adding tests for the new feature.

First one is parallelization. Since you serialize options to provide them to workers, providing the parser object just won't work apparently.
I see 2 possible solutions:
- allow users to provide the parser package name instead, and require it into `minify` function
- state that these features are mutually exclusive

Second one is that invalid CSS will throw an error, I think due to `MiniCssExtractPlugin`, but the test itself is about catching and fixing invalid CSS (together with other hacks from http://browserhacks.com/). I don't have a clear picture on what's going on here, can you provide any guidance? Is it possible to provide the parser to `MiniCssExtractPlugin` too?

Into Quasar codebase we also use `MiniCssExtractPlugin` so I'm interested into how to make those work together. Previously we used https://github.com/NMFR/optimize-css-assets-webpack-plugin as a plugin (instead of into "optimizations" property) and I think that's what allowed everything to work together, maybe because the CSS was first parsed and fixed by `postcss-safe-parser`, but I may be wrong