### PR TITLE
Refactor: dropped support `css` key from output `minify` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ module.exports = {
             .process(input, postcssOptions)
             .then((result) => {
               return {
-                css: result.css,
+                code: result.css,
                 map: result.map,
                 warnings: result.warnings(),
               };
@@ -453,7 +453,7 @@ module.exports = {
           }
 
           return {
-            css: minifiedCss.css,
+            code: minifiedCss.css,
             map: minifiedCss.map.toJSON(),
           };
         },
@@ -492,7 +492,7 @@ module.exports = {
           });
 
           return {
-            css: minifiedCss.styles,
+            code: minifiedCss.styles,
             map: minifiedCss.sourceMap.toJSON(),
             warnings: minifiedCss.warnings,
           };

--- a/src/minify.js
+++ b/src/minify.js
@@ -22,8 +22,7 @@ const minify = async (options) => {
   );
 
   return {
-    // TODO remove `css` in future major release
-    code: result.code || result.css,
+    code: result.code,
     map: result.map,
     warnings: warningsToString(result.warnings || []),
   };

--- a/test/CssMinimizerPlugin.test.js
+++ b/test/CssMinimizerPlugin.test.js
@@ -95,7 +95,7 @@ describe('CssMinimizerPlugin', () => {
         // eslint-disable-next-line no-console
         process.stderr.write('stderr\n');
 
-        return { css: '.minify {};' };
+        return { code: '.minify {};' };
       },
     }).apply(compiler);
 
@@ -318,7 +318,7 @@ describe('CssMinimizerPlugin', () => {
           .process(input, { from: filename, to: filename })
           .then((result) => {
             return {
-              css: result.css,
+              code: result.css,
               map: result.map,
               warnings: result.warnings(),
             };
@@ -797,7 +797,7 @@ describe('CssMinimizerPlugin', () => {
           .process(input, { from: fileName, to: fileName })
           .then((result) => {
             return {
-              css: result.css,
+              code: result.css,
               map: result.map,
               error: result.error,
               warnings: result.warnings(),
@@ -874,7 +874,7 @@ describe('CssMinimizerPlugin', () => {
           .process(input, { from: fileName, to: fileName })
           .then((result) => {
             return {
-              css: result.css,
+              code: result.css,
               map: result.map,
               error: result.error,
               warnings: result.warnings(),

--- a/test/cache-option.test.js
+++ b/test/cache-option.test.js
@@ -329,7 +329,7 @@ describe('"cache" option', () => {
           .process(input, { from: fileName, to: fileName })
           .then((result) => {
             return {
-              css: result.css,
+              code: result.css,
               map: result.map,
               error: result.error,
               warnings: result.warnings(),

--- a/test/minify-option.test.js
+++ b/test/minify-option.test.js
@@ -54,7 +54,7 @@ describe('"minify" option', () => {
         }
 
         return {
-          css: minifiedCss.css,
+          code: minifiedCss.css,
           map: minifiedCss.map.toJSON(),
         };
       },
@@ -93,7 +93,7 @@ describe('"minify" option', () => {
         });
 
         return {
-          css: minifiedCss.styles,
+          code: minifiedCss.styles,
           // map: minifiedCss.sourceMap.toJSON(),
           warnings: minifiedCss.warnings,
         };
@@ -139,21 +139,21 @@ describe('"minify" option', () => {
         async (data, inputMap, minimizerOptions) => {
           const [input] = Object.values(data);
           return {
-            css: `${input}\n.one{color: red;}\n${minimizerOptions.test}\n`,
+            code: `${input}\n.one{color: red;}\n${minimizerOptions.test}\n`,
             map: inputMap,
           };
         },
         async (data, inputMap, minimizerOptions) => {
           const [input] = Object.values(data);
           return {
-            css: `${input}\n.two{color: red;}\n${minimizerOptions.test}\n`,
+            code: `${input}\n.two{color: red;}\n${minimizerOptions.test}\n`,
             map: inputMap,
           };
         },
         async (data, inputMap, minimizerOptions) => {
           const [input] = Object.values(data);
           return {
-            css: `${input}\n.three{color: red;}\n${minimizerOptions.test}\n`,
+            code: `${input}\n.three{color: red;}\n${minimizerOptions.test}\n`,
             map: inputMap,
           };
         },
@@ -195,21 +195,21 @@ describe('"minify" option', () => {
         async (data, inputMap, minimizerOptions) => {
           const [input] = Object.values(data);
           return {
-            css: `${input}\n.one{color: red;}\n${minimizerOptions.test}\n`,
+            code: `${input}\n.one{color: red;}\n${minimizerOptions.test}\n`,
             map: inputMap,
           };
         },
         async (data, inputMap) => {
           const [input] = Object.values(data);
           return {
-            css: `${input}\n.two{color: red;}\n`,
+            code: `${input}\n.two{color: red;}\n`,
             map: inputMap,
           };
         },
         async (data, inputMap) => {
           const [input] = Object.values(data);
           return {
-            css: `${input}\n.three{color: red;}\n`,
+            code: `${input}\n.three{color: red;}\n`,
             map: inputMap,
           };
         },

--- a/test/warningsFilter-option.test.js
+++ b/test/warningsFilter-option.test.js
@@ -35,7 +35,7 @@ describe('warningsFilter option', () => {
           .process(input, { from: fileName, to: fileName })
           .then((result) => {
             return {
-              css: result.css,
+              code: result.css,
               map: result.map,
               error: result.error,
               warnings: result.warnings(),

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -55,7 +55,7 @@ describe('worker', () => {
       input: '.foo{color:red;}\n.bar{color:coral;}',
       minimizerOptions: { discardComments: false },
       minify: () => {
-        return { css: '.minify {};' };
+        return { code: '.minify {};' };
       },
     };
     const { code, map } = await transform(serialize(options));


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Previously, the `minifi` function returned the css result as a key `code` or `css`.
Now - only in the key of `code`.

### Breaking Changes

Yes

### Additional Info

No
