### PR TITLE
feat: removed cjs wrapper and generated types in commonjs format

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
     "type": "opencollective",
     "url": "https://opencollective.com/webpack"
   },
-  "main": "dist/cjs.js",
-  "types": "types/cjs.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">= 12.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
     "clean": "del-cli dist",
-    "prebuild": "npm run clean",
-    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write && prettier types --write",
+    "prebuild": "npm run clean types",
+    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",
     "build": "npm-run-all -p \"build:**\"",
     "commitlint": "commitlint --from=master",

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,3 +1,0 @@
-const plugin = require("./index");
-
-module.exports = plugin.default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,20 @@
-import * as os from "os";
+const os = require("os");
 
-import { SourceMapConsumer } from "source-map";
-import { validate } from "schema-utils";
-import serialize from "serialize-javascript";
-import { Worker } from "jest-worker";
+const { SourceMapConsumer } = require("source-map");
+const { validate } = require("schema-utils");
+const serialize = require("serialize-javascript");
+const { Worker } = require("jest-worker");
 
-import {
+const {
   throttleAll,
   cssnanoMinify,
   cssoMinify,
   cleanCssMinify,
   esbuildMinify,
-} from "./utils";
+} = require("./utils");
 
-import * as schema from "./options.json";
-import { minify as minifyFn } from "./minify";
+const schema = require("./options.json");
+const { minify } = require("./minify");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -529,7 +529,7 @@ class CssMinimizerPlugin {
           try {
             result = await (getWorker
               ? getWorker().transform(serialize(options))
-              : minifyFn(options));
+              : minify(options));
           } catch (error) {
             const hasSourceMap =
               inputSourceMap && CssMinimizerPlugin.isSourceMap(inputSourceMap);
@@ -715,4 +715,4 @@ CssMinimizerPlugin.cssoMinify = cssoMinify;
 CssMinimizerPlugin.cleanCssMinify = cleanCssMinify;
 CssMinimizerPlugin.esbuildMinify = esbuildMinify;
 
-export default CssMinimizerPlugin;
+module.exports = CssMinimizerPlugin;

--- a/src/minify.js
+++ b/src/minify.js
@@ -82,5 +82,4 @@ async function transform(options) {
   return minify(evaluatedOptions);
 }
 
-module.exports.minify = minify;
-module.exports.transform = transform;
+module.exports = { minify, transform };

--- a/src/utils.js
+++ b/src/utils.js
@@ -347,7 +347,7 @@ async function esbuildMinify(input, sourceMap, minimizerOptions) {
   };
 }
 
-export {
+module.exports = {
   throttleAll,
   cssnanoMinify,
   cssoMinify,

--- a/test/cache-option.test.js
+++ b/test/cache-option.test.js
@@ -92,6 +92,12 @@ describe('"cache" option', () => {
     expect(readAssets(compiler, newStats, /\.css$/)).toMatchSnapshot("assets");
     expect(getErrors(newStats)).toMatchSnapshot("errors");
     expect(getWarnings(newStats)).toMatchSnapshot("warnings");
+
+    await new Promise((resolve) => {
+      compiler.close(() => {
+        resolve();
+      });
+    });
   });
 
   it('should work with the "memory" value for the "cache.type" option', async () => {
@@ -154,6 +160,12 @@ describe('"cache" option', () => {
     expect(readAssets(compiler, newStats, /\.css$/)).toMatchSnapshot("assets");
     expect(getErrors(newStats)).toMatchSnapshot("errors");
     expect(getWarnings(newStats)).toMatchSnapshot("warnings");
+
+    await new Promise((resolve) => {
+      compiler.close(() => {
+        resolve();
+      });
+    });
   });
 
   it('should work with the "filesystem" value for the "cache.type" option', async () => {
@@ -217,6 +229,12 @@ describe('"cache" option', () => {
     expect(readAssets(compiler, newStats, /\.css$/)).toMatchSnapshot("assets");
     expect(getErrors(newStats)).toMatchSnapshot("errors");
     expect(getWarnings(newStats)).toMatchSnapshot("warnings");
+
+    await new Promise((resolve) => {
+      compiler.close(() => {
+        resolve();
+      });
+    });
   });
 
   it('should work with the "filesystem" value for the "cache.type" option and source maps', async () => {

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,8 +1,0 @@
-import src from "../src";
-import cjs from "../src/cjs";
-
-describe("CJS", () => {
-  it("should export loader", () => {
-    expect(cjs).toEqual(src);
-  });
-});

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -1,3 +1,0 @@
-declare const _exports: typeof plugin.default;
-export = _exports;
-import plugin = require("./index");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,124 +1,4 @@
-export default CssMinimizerPlugin;
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type Compiler = import("webpack").Compiler;
-export type Compilation = import("webpack").Compilation;
-export type WebpackError = import("webpack").WebpackError;
-export type JestWorker = import("jest-worker").Worker;
-export type RawSourceMap = import("source-map").RawSourceMap;
-export type CssNanoOptions = import("cssnano").CssNanoOptions;
-export type Asset = import("webpack").Asset;
-export type ProcessOptions = import("postcss").ProcessOptions;
-export type Syntax = import("postcss").Syntax;
-export type Parser = import("postcss").Parser;
-export type Stringifier = import("postcss").Stringifier;
-export type Warning =
-  | (Error & {
-      plugin?: string;
-      text?: string;
-      source?: string;
-    })
-  | string;
-export type WarningObject = {
-  message: string;
-  plugin?: string | undefined;
-  text?: string | undefined;
-  line?: number | undefined;
-  column?: number | undefined;
-};
-export type ErrorObject = {
-  message: string;
-  line?: number | undefined;
-  column?: number | undefined;
-  stack?: string | undefined;
-};
-export type MinimizedResult = {
-  code: string;
-  map?: import("source-map").RawSourceMap | undefined;
-  errors?: (string | Error | ErrorObject)[] | undefined;
-  warnings?: (Warning | WarningObject)[] | undefined;
-};
-export type Input = {
-  [file: string]: string;
-};
-export type CustomOptions = {
-  [key: string]: any;
-};
-export type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-export type BasicMinimizerImplementation<T> = (
-  input: Input,
-  sourceMap: RawSourceMap | undefined,
-  minifyOptions: InferDefaultType<T>
-) => Promise<MinimizedResult>;
-export type MinimizerImplementation<T> = T extends any[]
-  ? { [P in keyof T]: BasicMinimizerImplementation<T[P]> }
-  : BasicMinimizerImplementation<T>;
-export type MinimizerOptions<T> = T extends any[]
-  ? { [P in keyof T]?: InferDefaultType<T[P]> | undefined }
-  : InferDefaultType<T>;
-export type InternalOptions<T> = {
-  name: string;
-  input: string;
-  inputSourceMap: RawSourceMap | undefined;
-  minimizer: {
-    implementation: MinimizerImplementation<T>;
-    options: MinimizerOptions<T>;
-  };
-};
-export type InternalResult = {
-  outputs: Array<{
-    code: string;
-    map: RawSourceMap | undefined;
-  }>;
-  warnings: Array<Warning | WarningObject | string>;
-  errors: Array<Error | ErrorObject | string>;
-};
-export type Parallel = undefined | boolean | number;
-export type Rule = RegExp | string;
-export type Rules = Rule[] | Rule;
-export type WarningsFilter = (
-  warning: Warning | WarningObject | string,
-  file: string,
-  source?: string | undefined
-) => boolean;
-export type BasePluginOptions = {
-  test?: Rules | undefined;
-  include?: Rules | undefined;
-  exclude?: Rules | undefined;
-  warningsFilter?: WarningsFilter | undefined;
-  parallel?: Parallel;
-};
-export type MinimizerWorker<T> = Worker & {
-  transform: (options: string) => InternalResult;
-  minify: (options: InternalOptions<T>) => InternalResult;
-};
-export type ProcessOptionsExtender =
-  | ProcessOptions
-  | {
-      from?: string;
-      to?: string;
-      parser?: string | Syntax | Parser;
-      stringifier?: string | Syntax | Stringifier;
-      syntax?: string | Syntax;
-    };
-export type CssNanoOptionsExtended = CssNanoOptions & {
-  processorOptions?: ProcessOptionsExtender;
-};
-export type DefinedDefaultMinimizerAndOptions<T> =
-  T extends CssNanoOptionsExtended
-    ? {
-        minify?: MinimizerImplementation<T> | undefined;
-        minimizerOptions?: MinimizerOptions<T> | undefined;
-      }
-    : {
-        minify: MinimizerImplementation<T>;
-        minimizerOptions?: MinimizerOptions<T> | undefined;
-      };
-export type InternalPluginOptions<T> = BasePluginOptions & {
-  minimizer: {
-    implementation: MinimizerImplementation<T>;
-    options: MinimizerOptions<T>;
-  };
-};
+export = CssMinimizerPlugin;
 /**
  * @template [T=CssNanoOptionsExtended]
  */
@@ -183,13 +63,169 @@ declare class CssMinimizerPlugin<T = CssNanoOptionsExtended> {
   apply(compiler: Compiler): void;
 }
 declare namespace CssMinimizerPlugin {
-  export { cssnanoMinify };
-  export { cssoMinify };
-  export { cleanCssMinify };
-  export { esbuildMinify };
+  export {
+    cssnanoMinify,
+    cssoMinify,
+    cleanCssMinify,
+    esbuildMinify,
+    Schema,
+    Compiler,
+    Compilation,
+    WebpackError,
+    JestWorker,
+    RawSourceMap,
+    CssNanoOptions,
+    Asset,
+    ProcessOptions,
+    Syntax,
+    Parser,
+    Stringifier,
+    Warning,
+    WarningObject,
+    ErrorObject,
+    MinimizedResult,
+    Input,
+    CustomOptions,
+    InferDefaultType,
+    BasicMinimizerImplementation,
+    MinimizerImplementation,
+    MinimizerOptions,
+    InternalOptions,
+    InternalResult,
+    Parallel,
+    Rule,
+    Rules,
+    WarningsFilter,
+    BasePluginOptions,
+    MinimizerWorker,
+    ProcessOptionsExtender,
+    CssNanoOptionsExtended,
+    DefinedDefaultMinimizerAndOptions,
+    InternalPluginOptions,
+  };
 }
-import { Worker } from "jest-worker";
+type CssNanoOptionsExtended = CssNanoOptions & {
+  processorOptions?: ProcessOptionsExtender;
+};
+type Compiler = import("webpack").Compiler;
+type BasePluginOptions = {
+  test?: Rules | undefined;
+  include?: Rules | undefined;
+  exclude?: Rules | undefined;
+  warningsFilter?: WarningsFilter | undefined;
+  parallel?: Parallel;
+};
+type DefinedDefaultMinimizerAndOptions<T> = T extends CssNanoOptionsExtended
+  ? {
+      minify?: MinimizerImplementation<T> | undefined;
+      minimizerOptions?: MinimizerOptions<T> | undefined;
+    }
+  : {
+      minify: MinimizerImplementation<T>;
+      minimizerOptions?: MinimizerOptions<T> | undefined;
+    };
 import { cssnanoMinify } from "./utils";
 import { cssoMinify } from "./utils";
 import { cleanCssMinify } from "./utils";
 import { esbuildMinify } from "./utils";
+type Schema = import("schema-utils/declarations/validate").Schema;
+type Compilation = import("webpack").Compilation;
+type WebpackError = import("webpack").WebpackError;
+type JestWorker = import("jest-worker").Worker;
+type RawSourceMap = import("source-map").RawSourceMap;
+type CssNanoOptions = import("cssnano").CssNanoOptions;
+type Asset = import("webpack").Asset;
+type ProcessOptions = import("postcss").ProcessOptions;
+type Syntax = import("postcss").Syntax;
+type Parser = import("postcss").Parser;
+type Stringifier = import("postcss").Stringifier;
+type Warning =
+  | (Error & {
+      plugin?: string;
+      text?: string;
+      source?: string;
+    })
+  | string;
+type WarningObject = {
+  message: string;
+  plugin?: string | undefined;
+  text?: string | undefined;
+  line?: number | undefined;
+  column?: number | undefined;
+};
+type ErrorObject = {
+  message: string;
+  line?: number | undefined;
+  column?: number | undefined;
+  stack?: string | undefined;
+};
+type MinimizedResult = {
+  code: string;
+  map?: import("source-map").RawSourceMap | undefined;
+  errors?: (string | Error | ErrorObject)[] | undefined;
+  warnings?: (Warning | WarningObject)[] | undefined;
+};
+type Input = {
+  [file: string]: string;
+};
+type CustomOptions = {
+  [key: string]: any;
+};
+type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
+type BasicMinimizerImplementation<T> = (
+  input: Input,
+  sourceMap: RawSourceMap | undefined,
+  minifyOptions: InferDefaultType<T>
+) => Promise<MinimizedResult>;
+type MinimizerImplementation<T> = T extends any[]
+  ? { [P in keyof T]: BasicMinimizerImplementation<T[P]> }
+  : BasicMinimizerImplementation<T>;
+type MinimizerOptions<T> = T extends any[]
+  ? { [P in keyof T]?: InferDefaultType<T[P]> | undefined }
+  : InferDefaultType<T>;
+type InternalOptions<T> = {
+  name: string;
+  input: string;
+  inputSourceMap: RawSourceMap | undefined;
+  minimizer: {
+    implementation: MinimizerImplementation<T>;
+    options: MinimizerOptions<T>;
+  };
+};
+type InternalResult = {
+  outputs: Array<{
+    code: string;
+    map: RawSourceMap | undefined;
+  }>;
+  warnings: Array<Warning | WarningObject | string>;
+  errors: Array<Error | ErrorObject | string>;
+};
+type Parallel = undefined | boolean | number;
+type Rule = RegExp | string;
+type Rules = Rule[] | Rule;
+type WarningsFilter = (
+  warning: Warning | WarningObject | string,
+  file: string,
+  source?: string | undefined
+) => boolean;
+type MinimizerWorker<T> = Worker & {
+  transform: (options: string) => InternalResult;
+  minify: (options: InternalOptions<T>) => InternalResult;
+};
+type ProcessOptionsExtender =
+  | ProcessOptions
+  | {
+      from?: string;
+      to?: string;
+      parser?: string | Syntax | Parser;
+      stringifier?: string | Syntax | Stringifier;
+      syntax?: string | Syntax;
+    };
+type InternalPluginOptions<T> = BasePluginOptions & {
+  minimizer: {
+    implementation: MinimizerImplementation<T>;
+    options: MinimizerOptions<T>;
+  };
+};
+import { minify } from "./minify";
+import { Worker } from "jest-worker";


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

removed cjs wrapper and generated types in commonjs format (`export =` and `namespaces` used in types), now you can directly use exported types

### Breaking Changes

Potentially yes, but we use `babel` and our format is commonjs, but types in ESM, it is bug, also now you can reuse our types 

### Additional Info

No