### PR TITLE
fix: use os.availableParallelism() for parallelism when it is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Type: `Boolean|Number`
 Default: `true`
 
 Use multi-process parallel running to improve the build speed.
-Default number of concurrent runs: `os.cpus().length - 1`.
+Default number of concurrent runs: `os.cpus().length - 1` or `os.availableParallelism() - 1` (if this function is supported).
 
 > ℹ️ Parallelization can speed up your build significantly and is therefore **highly recommended**.
 > If a parallelization is enabled, the packages in `minimizerOptions` must be required via strings (`packageName` or `require.resolve(packageName)`). Read more in [`minimizerOptions`](#minimizeroptions)

--- a/src/index.js
+++ b/src/index.js
@@ -389,11 +389,14 @@ class CssMinimizerPlugin {
   static getAvailableNumberOfCores(parallel) {
     // In some cases cpus() returns undefined
     // https://github.com/nodejs/node/issues/19022
-    const cpus = os.cpus() || { length: 1 };
+    const cpus =
+      typeof os.availableParallelism === "function"
+        ? { length: os.availableParallelism() }
+        : os.cpus() || { length: 1 };
 
-    return parallel === true
+    return parallel === true || typeof parallel === "undefined"
       ? cpus.length - 1
-      : Math.min(Number(parallel) || 0, cpus.length - 1);
+      : Math.min(parallel || 0, cpus.length - 1);
   }
 
   /**
@@ -681,7 +684,6 @@ class CssMinimizerPlugin {
       getWorker && numberOfAssetsForMinify > 0
         ? /** @type {number} */ (numberOfWorkers)
         : scheduledTasks.length;
-
     await throttleAll(limit, scheduledTasks);
 
     if (initializedWorker) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -186,6 +186,8 @@ async function cssnanoMinify(
   };
 }
 
+cssnanoMinify.supportsWorkerThreads = () => true;
+
 /* istanbul ignore next */
 /**
  * @param {Input} input
@@ -212,6 +214,8 @@ async function cssoMinify(input, sourceMap, minimizerOptions) {
         undefined,
   };
 }
+
+cssoMinify.supportsWorkerThreads = () => true;
 
 /* istanbul ignore next */
 /**
@@ -255,6 +259,8 @@ async function cleanCssMinify(input, sourceMap, minimizerOptions) {
     warnings: result.warnings,
   };
 }
+
+cleanCssMinify.supportsWorkerThreads = () => true;
 
 /* istanbul ignore next */
 /**
@@ -347,6 +353,8 @@ async function esbuildMinify(input, sourceMap, minimizerOptions) {
   };
 }
 
+esbuildMinify.supportsWorkerThreads = () => false;
+
 // TODO remove in the next major release
 /* istanbul ignore next */
 /**
@@ -392,6 +400,8 @@ async function parcelCssMinify(input, sourceMap, minimizerOptions) {
   };
 }
 
+parcelCssMinify.supportsWorkerThreads = () => false;
+
 /* istanbul ignore next */
 /**
  * @param {Input} input
@@ -435,6 +445,8 @@ async function lightningCssMinify(input, sourceMap, minimizerOptions) {
     map: result.map ? JSON.parse(result.map.toString()) : undefined,
   };
 }
+
+lightningCssMinify.supportsWorkerThreads = () => false;
 
 /* istanbul ignore next */
 /**
@@ -489,6 +501,8 @@ async function swcMinify(input, sourceMap, minimizerOptions) {
         undefined,
   };
 }
+
+swcMinify.supportsWorkerThreads = () => false;
 
 /**
  * @template T

--- a/test/__snapshots__/parallel-option.test.js.snap
+++ b/test/__snapshots__/parallel-option.test.js.snap
@@ -90,6 +90,19 @@ exports[`parallel option should match snapshot for the "true" value: errors 1`] 
 
 exports[`parallel option should match snapshot for the "true" value: warnings 1`] = `[]`;
 
+exports[`parallel option should match snapshot for the "undefined" value: assets 1`] = `
+{
+  "four.css": "body{color:red}a{color:blue}",
+  "one.css": "body{color:red}a{color:blue}",
+  "three.css": "body{color:red}a{color:blue}",
+  "two.css": "body{color:red}a{color:blue}",
+}
+`;
+
+exports[`parallel option should match snapshot for the "undefined" value: errors 1`] = `[]`;
+
+exports[`parallel option should match snapshot for the "undefined" value: warnings 1`] = `[]`;
+
 exports[`parallel option should match snapshot when a value is not specify: assets 1`] = `
 {
   "four.css": "body{color:red}a{color:blue}",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,6 +35,13 @@ declare class CssMinimizerPlugin<T = CssNanoOptionsExtended> {
    */
   private static getAvailableNumberOfCores;
   /**
+   * @private
+   * @template T
+   * @param {BasicMinimizerImplementation<T> & MinimizeFunctionHelpers} implementation
+   * @returns {boolean}
+   */
+  private static isSupportsWorkerThreads;
+  /**
    * @param {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>} [options]
    */
   constructor(
@@ -91,9 +98,10 @@ declare namespace CssMinimizerPlugin {
     Input,
     CustomOptions,
     InferDefaultType,
-    BasicMinimizerImplementation,
-    MinimizerImplementation,
     MinimizerOptions,
+    BasicMinimizerImplementation,
+    MinimizeFunctionHelpers,
+    MinimizerImplementation,
     InternalOptions,
     InternalResult,
     Parallel,
@@ -164,17 +172,23 @@ type CustomOptions = {
   [key: string]: any;
 };
 type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
+type MinimizerOptions<T> = T extends any[]
+  ? { [P in keyof T]?: InferDefaultType<T[P]> }
+  : InferDefaultType<T>;
 type BasicMinimizerImplementation<T> = (
   input: Input,
   sourceMap: RawSourceMap | undefined,
   minifyOptions: InferDefaultType<T>,
 ) => Promise<MinimizedResult>;
+type MinimizeFunctionHelpers = {
+  supportsWorkerThreads?: (() => boolean | undefined) | undefined;
+};
 type MinimizerImplementation<T> = T extends any[]
-  ? { [P in keyof T]: BasicMinimizerImplementation<T[P]> }
-  : BasicMinimizerImplementation<T>;
-type MinimizerOptions<T> = T extends any[]
-  ? { [P in keyof T]?: InferDefaultType<T[P]> }
-  : InferDefaultType<T>;
+  ? {
+      [P in keyof T]: BasicMinimizerImplementation<T[P]> &
+        MinimizeFunctionHelpers;
+    }
+  : BasicMinimizerImplementation<T> & MinimizeFunctionHelpers;
 type InternalOptions<T> = {
   name: string;
   input: string;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -34,6 +34,9 @@ export function cssnanoMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions?: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace cssnanoMinify {
+  function supportsWorkerThreads(): boolean;
+}
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
@@ -45,6 +48,9 @@ export function cssoMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace cssoMinify {
+  function supportsWorkerThreads(): boolean;
+}
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
@@ -56,6 +62,9 @@ export function cleanCssMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace cleanCssMinify {
+  function supportsWorkerThreads(): boolean;
+}
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
@@ -67,6 +76,9 @@ export function esbuildMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace esbuildMinify {
+  function supportsWorkerThreads(): boolean;
+}
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
@@ -78,6 +90,9 @@ export function parcelCssMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace parcelCssMinify {
+  function supportsWorkerThreads(): boolean;
+}
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
@@ -89,6 +104,9 @@ export function lightningCssMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace lightningCssMinify {
+  function supportsWorkerThreads(): boolean;
+}
 /**
  * @param {Input} input
  * @param {RawSourceMap | undefined} sourceMap
@@ -100,3 +118,6 @@ export function swcMinify(
   sourceMap: RawSourceMap | undefined,
   minimizerOptions: CustomOptions,
 ): Promise<MinimizedResult>;
+export namespace swcMinify {
+  function supportsWorkerThreads(): boolean;
+}


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

use os.availableParallelism() for parallelism when it is available

### Breaking Changes

No

### Additional Info

No